### PR TITLE
Added github CI

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.7, 3.8]
     steps:
     - uses: goanpeca/setup-miniconda@v1
       with:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,0 +1,44 @@
+name: PhyloPhlAn
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: build (${{ matrix.python-version }}, ${{ matrix.os }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+    steps:
+    - uses: goanpeca/setup-miniconda@v1
+      with:
+        miniconda-version: 'latest'
+        auto-update-conda: true
+        python-version: ${{ matrix.python-version }}
+        channels: conda-forge,bioconda
+        activate-environment: TEMPLATE
+    - name: conda env setup
+      shell: bash -l {0}
+      run: |
+        conda info -a
+        conda install python=${{ matrix.python-version }} bioconda::phylophlan
+    - uses: actions/checkout@v2	
+    - name: package install
+      shell: bash -l {0}
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest pytest-dependency pytest-console-scripts
+        pip install . --ignore-installed --no-deps -vv
+    - name: Test with pytest
+      shell: bash -l {0}
+      run: |
+        pytest -s --script-launch-mode=subprocess
+    - name: Test example 01_saureus
+      shell: bash -l {0}
+      run: |
+        bash phylophlan/examples/01_saureus/run_01_mini.sh
+

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ phylophlan/pcopri
 # temp files and folders
 __pycache__
 .nfs*
+tmp/

--- a/phylophlan/examples/01_saureus/run_01_mini.sh
+++ b/phylophlan/examples/01_saureus/run_01_mini.sh
@@ -78,7 +78,7 @@ phylophlan_write_config_file -o references_config.cfg \
     --msa mafft \
     --trim trimal \
     --tree1 fasttree \
-    --tree2 fasttree \
+    --tree2 raxml \
     > /dev/null || exit 1
 
 echo "# Building the phylogeny of the 15 S. aureus genomes"
@@ -86,6 +86,10 @@ phylophlan \
     -i input_references \
     -o output_references \
     -d s__Staphylococcus_aureus \
+    --trim greedy \
+    --not_variant_threshold 0.99 \
+    --remove_fragmentary_entries \
+    --fragmentary_threshold 0.67 \
     -t a \
     --min_num_proteins 1 \
     --min_num_entries 4 \
@@ -93,8 +97,6 @@ phylophlan \
     --configs_folder $CONFIG_DIR \
     -f references_config.cfg \
     --nproc 2 \
-    --subsample twentyfivepercent \
     --diversity low \
     --fast \
     > /dev/null || exit 1
-

--- a/phylophlan/examples/01_saureus/run_01_mini.sh
+++ b/phylophlan/examples/01_saureus/run_01_mini.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+cd $SCRIPT_DIR || exit 1
+
+echo "# Downloading 10 S. aureus isolate genomes"
+rm -rf input_isolates
+mkdir -p input_isolates
+
+for i in $(cut -f4 135_saureus_isolates.tsv | sed 1d | head -n 11); do
+    o=`basename $i | cut -f1 -d'.'`;
+    wget $i -O input_isolates/${o}.fna.gz;
+done;
+
+echo "# Generating S. aureus database based on UniRef90"
+phylophlan_setup_database \
+    -g s__Staphylococcus_aureus \
+    --max_proteins 100 \
+    --overwrite \
+    --verbose || exit 1
+
+echo "# Writing default config"
+CONFIG_DIR='configs'
+phylophlan_write_default_configs.sh $CONFIG_DIR
+
+echo "# Writing isolates config file"
+phylophlan_write_config_file -o isolates_config.cfg \
+    --overwrite \
+    -d a \
+    --force_nucleotides \
+    --db_aa diamond \
+    --map_aa diamond \
+    --map_dna diamond \
+    --msa mafft \
+    --trim trimal \
+    --tree1 fasttree \
+    --tree2 raxml || exit 1
+
+echo "# Building the phylogeny of the 10 S. aureus strains"
+phylophlan \
+    -i input_isolates \
+    -o output_isolates \
+    -d s__Staphylococcus_aureus \
+    --trim greedy \
+    --not_variant_threshold 0.99 \
+    --remove_fragmentary_entries \
+    --fragmentary_threshold 0.67 \
+    --min_num_proteins 1 \
+    --min_num_entries 4 \
+    --min_num_markers 1 \
+    -t a \
+    --configs_folder $CONFIG_DIR \
+    -f isolates_config.cfg \
+    --diversity low \
+    --force_nucleotides \
+    --nproc 2 \
+    --verbose || exit 1
+
+echo "# Adding 5 S. aureus reference genomes"
+phylophlan_get_reference \
+    -g s__Staphylococcus_aureus \
+    -o input_references \
+    -n 5 \
+    --verbose || exit 1
+
+cp -a input_isolates/* input_references/ || exit 1
+
+echo "# Building the phylogeny of the 15 S. aureus genomes"
+phylophlan \
+    -i input_references \
+    -o output_references \
+    -d s__Staphylococcus_aureus \
+    -t a \
+    --min_num_proteins 1 \
+    --min_num_entries 4 \
+    --min_num_markers 1 \
+    -f references_config.cfg \
+    --nproc 2 \
+    --subsample twentyfivepercent \
+    --diversity low \
+    --fast \
+    --verbose || exit 1
+

--- a/phylophlan/examples/01_saureus/run_01_mini.sh
+++ b/phylophlan/examples/01_saureus/run_01_mini.sh
@@ -78,7 +78,7 @@ phylophlan_write_config_file -o references_config.cfg \
     --msa mafft \
     --trim trimal \
     --tree1 fasttree \
-    --tree2 raxml \
+    --tree2 fasttree \
     > /dev/null || exit 1
 
 echo "# Building the phylogeny of the 15 S. aureus genomes"

--- a/phylophlan/examples/01_saureus/run_01_mini.sh
+++ b/phylophlan/examples/01_saureus/run_01_mini.sh
@@ -81,22 +81,30 @@ phylophlan_write_config_file -o references_config.cfg \
     --tree2 raxml \
     > /dev/null || exit 1
 
-echo "# Building the phylogeny of the 15 S. aureus genomes"
-phylophlan \
-    -i input_references \
-    -o output_references \
-    -d s__Staphylococcus_aureus \
-    --trim greedy \
-    --not_variant_threshold 0.99 \
-    --remove_fragmentary_entries \
-    --fragmentary_threshold 0.67 \
-    -t a \
-    --min_num_proteins 1 \
-    --min_num_entries 4 \
-    --min_num_markers 1 \
-    --configs_folder $CONFIG_DIR \
-    -f references_config.cfg \
-    --nproc 2 \
-    --diversity low \
-    --fast \
-    > /dev/null || exit 1
+# echo "# Building the phylogeny of the 15 S. aureus genomes"
+# phylophlan.py \
+#     -i input_references \
+#     -o output_references \
+#     -d s__Staphylococcus_aureus \
+#     -t a \
+#     --configs_folder $CONFIG_DIR \
+#     -f references_config.cfg \
+#     --nproc 4 \
+#     --subsample twentyfivepercent \
+#     --diversity low \
+#     --fast \
+#     > /dev/null || exit 1
+
+# # Visualize the phylogenetic tree with GraPhlAn
+# # GraPhlAn is Python2-based and have different requirements than PhyloPhlAn
+# echo "GraPhlAn annotate"
+# graphlan_annotate.py \
+#     --annot graphlan/isolates_annotation.txt \
+#     output_isolates/RAxML_bestTree.input_isolates_refined.tre \
+#     graphlan/isolates_annotated.xml
+
+# echo "GraPhlAn draw"
+# graphlan.py \
+#     graphlan/isolates_annotated.xml \
+#     graphlan/saureus_isolates.png \
+#     --dpi 300

--- a/phylophlan/phylophlan_setup_database.py
+++ b/phylophlan/phylophlan_setup_database.py
@@ -78,6 +78,7 @@ def read_params():
     p.add_argument('-t', '--db_type', default=None, choices=DB_TYPE_CHOICES,
                    help='Specify the type of the database, where "n" stands for nucleotides and "a" for amino acids')
     p.add_argument('-x', '--output_extension', type=str, default=None, help="Set the database output extension")
+    p.add_argument('--max_proteins', type=int, default=None, help="Set a max number of proteins to download")
     p.add_argument('--overwrite', action='store_true', default=False, help="If specified and the output file exists it will be overwritten")
     p.add_argument('--citation', action='version',
                    version=('Asnicar, F., Thomas, A.M., Beghini, F. et al. '
@@ -260,7 +261,7 @@ def create_folder(output, verbose=False):
         info('Output "{}" folder present\n'.format(output))
 
 
-def get_core_proteins(taxa2core_file, taxa_label, output, output_extension, verbose=False):
+def get_core_proteins(taxa2core_file, taxa_label, output, output_extension, max_proteins=None, verbose=False):
     core_proteins = {}
     url = None
     retry2download = []
@@ -292,6 +293,10 @@ def get_core_proteins(taxa2core_file, taxa_label, output, output_extension, verb
     elif len([k for k, v in core_proteins.items() if v is not None]) > 1:
         error('{} entries found for "{}":\n{}    please check the taxonomic label provided'
               .format(len(core_proteins), taxa_label, '    - {}\n'.join(core_proteins.keys())), exit=True)
+    if max_proteins is not None:
+        for k,v in core_proteins.items():
+            core_proteins[k] = v[:max_proteins]
+        info('Reducing the number of proteins to the max of {}\n'.format(max_proteins))
 
     for lbl, core_prots in core_proteins.items():
         if core_prots is None:
@@ -398,10 +403,10 @@ def phylophlan_setup_database():
 
     check_params(args, verbose=args.verbose)
     create_folder(args.output, verbose=args.verbose)
-
+    
     if args.get_core_proteins:
         taxa2core_file_latest = database_update(update=args.database_update, verbose=args.verbose)
-        get_core_proteins(taxa2core_file_latest, args.get_core_proteins, args.output, args.output_extension, verbose=args.verbose)
+        get_core_proteins(taxa2core_file_latest, args.get_core_proteins, args.output, args.output_extension, max_proteins=args.max_proteins, verbose=args.verbose)
 
     create_database(args.db_name, args.input, args.input_extension, os.path.join(args.output, args.db_name + args.output_extension),
                     args.overwrite, verbose=args.verbose)

--- a/tests/test_phylophlan.py
+++ b/tests/test_phylophlan.py
@@ -1,0 +1,14 @@
+# import
+## batteries
+import os
+import sys
+import pytest
+
+# test/data dir
+test_dir = os.path.join(os.path.dirname(__file__))
+data_dir = os.path.join(test_dir, 'data')
+
+def test_help_docs(script_runner):
+    ret = script_runner.run('phylophlan', '-h')
+    assert ret.success
+


### PR DESCRIPTION
I set up github CI for phylophlan because i) it was absent from the repo ii) it was a way for me to learn how phylophlan3 worked. 

The CI includes basic testing via pytest (just a system-level check; no unit tests). 

The CI also includes an automated run of Example 01. I reduced the runtime by creating a `--max_proteins` param for `phylophlan_setup_database` and reducing the number of input genomes to 10. Note that running `phylophlan` on the input genomes + ref genomes (just used 5 refs) results in an error, which I couldn't fix, so maybe it's good to have Example 01 in the CI.

Feel free to consider this PR as a template if you just want to setup CI yourself and not actually merge these changes. I'd be happy to help with expanding the CI to other examples and unit tests.