### PR TITLE
modify TMPDIR for mafft only if not present in env

### DIFF
--- a/phylophlan/phylophlan_write_config_file.py
+++ b/phylophlan/phylophlan_write_config_file.py
@@ -276,13 +276,14 @@ def phylophlan_write_config_file():
                'version': '--version',
                'command_line': '#program_name# #params# #input# > #output#'}
 
-        for fld in ['/local-storage', '/tmp']:
-            if os.path.isdir(fld) and os.access(fld, os.W_OK) and os.access(fld, os.X_OK):
-                if 'environment' in msa:
-                    break
+        if not os.getenv('TMPDIR'):
+            for fld in ['/local-storage', '/tmp']:
+                if os.path.isdir(fld) and os.access(fld, os.W_OK) and os.access(fld, os.X_OK):
+                    if 'environment' in msa:
+                        break
 
-                msa['environment'] = 'TMPDIR={}'.format(fld)
-                break
+                    msa['environment'] = 'TMPDIR={}'.format(fld)
+                    break
     elif 'opal' in args.msa:
         exe, _ = find_executable_wrapper('opal', absolute=args.absolute_path)
         msa = {'program_name': exe,


### PR DESCRIPTION
Hi,

Thank you for your work.
Here is a small PR to assign a value to `TMPDIR` only if no value is already present in your system env.
I had an issue in our cluster system where we have a dedicated directory for temporary files which is set in the `TMPDIR` environment variable which was overridden by this part of the code.

Let me know if I should submit PR to the `dev` branch instead.

Best regards,
Kenzo